### PR TITLE
added atomic_open hook

### DIFF
--- a/src/redirfs/redirfs.h
+++ b/src/redirfs/redirfs.h
@@ -40,7 +40,7 @@
 #include <linux/aio.h>
 #include <linux/version.h>
 
-#define REDIRFS_VERSION "0.13 EXPERIMENTAL"
+#define REDIRFS_VERSION "0.14 EXPERIMENTAL"
 
 #define REDIRFS_PATH_INCLUDE        1
 #define REDIRFS_PATH_EXCLUDE        2
@@ -283,6 +283,7 @@ enum redirfs_op_idc {
 #endif
     REDIRFS_DIR_IOP_PERMISSION   = RFS_OP_IDC(RFS_INODE_DIR, RFS_OP_i_permission),
     REDIRFS_DIR_IOP_SETATTR      = RFS_OP_IDC(RFS_INODE_DIR, RFS_OP_i_setattr),
+    REDIRFS_DIR_IOP_ATOMIC_OPEN  = RFS_OP_IDC(RFS_INODE_DIR, RFS_OP_i_atomic_open),
 
     REDIRFS_CHR_IOP_PERMISSION   = RFS_OP_IDC(RFS_INODE_CHAR, RFS_OP_i_permission),
     REDIRFS_CHR_IOP_SETATTR      = RFS_OP_IDC(RFS_INODE_CHAR, RFS_OP_i_setattr),
@@ -604,6 +605,17 @@ union redirfs_op_args {
         struct dentry *dentry;
         struct iattr *iattr;
     } i_setattr;
+
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(3,5,0))
+    struct {
+        struct inode *inode;
+        struct dentry *dentry;
+        struct file *file;
+        unsigned open_flag;
+        umode_t create_mode;
+        int *opened;
+    } i_atomic_open;
+#endif
 
     struct {
         struct inode *inode;

--- a/src/redirfs/rfs.h
+++ b/src/redirfs/rfs.h
@@ -642,6 +642,7 @@ void rfs_file_put(struct rfs_file *rfile);
 void rfs_file_set_ops(struct rfs_file *rfile);
 int rfs_file_cache_create(void);
 void rfs_file_cache_destory(void);
+struct rfs_file *rfs_file_add(struct file *file);
 
 void rfs_add_dir_subs(
     struct rfs_file *rfile,

--- a/src/redirfs/rfs_dentry.c
+++ b/src/redirfs/rfs_dentry.c
@@ -70,9 +70,9 @@ struct rfs_dentry* rfs_dentry_find(const struct dentry *dentry)
     struct rfs_object  *robject;
 
 #ifdef RFS_PER_OBJECT_OPS
-    rdentry = rfs_dentry_get(rfs_cast_to_rdentry(dentry));
-    if (rdentry)
-        return rdentry;
+    rinode = rfs_dentry_get(rfs_cast_to_rdentry(dentry));
+    if (rinode)
+        return rinode;
 #endif /* RFS_PER_OBJECT_OPS */
 
     robject = rfs_get_object_by_system_object(&rfs_dentry_radix_tree, dentry);

--- a/src/redirfs/rfs_dentry.c
+++ b/src/redirfs/rfs_dentry.c
@@ -70,9 +70,9 @@ struct rfs_dentry* rfs_dentry_find(const struct dentry *dentry)
     struct rfs_object  *robject;
 
 #ifdef RFS_PER_OBJECT_OPS
-    rinode = rfs_dentry_get(rfs_cast_to_rdentry(dentry));
-    if (rinode)
-        return rinode;
+    rdentry = rfs_dentry_get(rfs_cast_to_rdentry(dentry));
+    if (rdentry)
+        return rdentry;
 #endif /* RFS_PER_OBJECT_OPS */
 
     robject = rfs_get_object_by_system_object(&rfs_dentry_radix_tree, dentry);

--- a/src/redirfs/rfs_file.c
+++ b/src/redirfs/rfs_file.c
@@ -230,7 +230,7 @@ static void rfs_file_free(struct rfs_object *robject)
 
 /*---------------------------------------------------------------------------*/
 
-static struct rfs_file *rfs_file_add(struct file *file)
+struct rfs_file *rfs_file_add(struct file *file)
 {
     struct rfs_file *rfile;
     int err;

--- a/src/redirfs/rfs_path.c
+++ b/src/redirfs/rfs_path.c
@@ -267,6 +267,8 @@ static int rfs_path_add_dirs(struct dentry *dentry)
 
 static int rfs_path_check_fs(struct file_system_type *type)
 {
+    return 0;
+/*
     if (!strcmp("cifs", type->name))
         goto notsup;
 
@@ -275,6 +277,7 @@ notsup:
     printk(KERN_ERR "redirfs does not support '%s' file system\n",
             type->name);
     return -1;
+*/
 }
 
 static int rfs_path_add_include(struct rfs_path *rpath, struct rfs_flt *rflt)


### PR DESCRIPTION
fix of operation hooks on created files

Steps to reproduce issue:
```
1. sudo mount -t nfs 10.1.184.133:/srv/nfsshare /mnt/nfs
2. sudo ./avfltctl/avfltctl -i /mnt/nfs
3. in other terminal: sudo ./avtest/avtest
4. echo 123 > /mnt/nfs/123.txt
5. nothing show in terminal of avtest/dummyflt
```