### PR TITLE
hook atomic_open when it exist in old inode ops

### DIFF
--- a/src/redirfs/rfs_inode.c
+++ b/src/redirfs/rfs_inode.c
@@ -1519,7 +1519,9 @@ static void rfs_inode_set_ops_dir(struct rfs_inode *rinode)
     RFS_SET_IOP_MGT(rinode, REDIRFS_DIR_IOP_LOOKUP, lookup, rfs_lookup);
     RFS_SET_IOP_MGT(rinode, REDIRFS_DIR_IOP_MKDIR, mkdir, rfs_mkdir);
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(3,5,0))
-    RFS_SET_IOP_MGT(rinode, REDIRFS_DIR_IOP_ATOMIC_OPEN, atomic_open, rfs_atomic_open);
+    // hook atomic_open when i_op has it
+    if (rinode->i_rhops->old.i_op->atomic_open)
+        RFS_SET_IOP_MGT(rinode, REDIRFS_DIR_IOP_ATOMIC_OPEN, atomic_open, rfs_atomic_open);
 #endif
 }
 


### PR DESCRIPTION
kernels check i_op->atomic_open pointer and use it when it exist.
RFS_SET_IOP_MGT -> RFS_ADD_OP_MGT set without check of existence operation.

Issue:
creating file gets error ENOSYS when fs (xfs, brtfs, ..) doesn't support atomic_open