### PR TITLE
Feature/cifs nfs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,7 @@ modules:
 	$(MAKE) -C $(KDIR) M=$(PWD) EXTRA_CFLAGS=$(MINC) modules
 
 modules_debug:
-	$(MAKE) -C $(KDIR) M=$(PWD) EXTRA_CFLAGS='$(MINC) -v -O1 -g -DRFS_DBG' modules
+	$(MAKE) -C $(KDIR) M=$(PWD) EXTRA_CFLAGS='$(MINC) -v -O1 -g -DRFS_DBG -DDEBUG' modules
 
 modules_install: modules
 	mkdir -p $(MDIR)
@@ -99,6 +99,8 @@ cscope_clean:
 # general targes
 
 all: libs utils modules cscope
+
+all_debug: libs utils modules_debug cscope
 
 clean: libs_clean utils_clean modules_clean cscope_clean
 

--- a/src/avflt/avflt.h
+++ b/src/avflt/avflt.h
@@ -33,6 +33,7 @@
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,20)
 #include <linux/freezer.h>
 #endif
+#include <linux/fs_struct.h>
 #include <linux/fs.h>
 #include <linux/slab.h>
 #include <redirfs.h>
@@ -178,6 +179,14 @@ extern atomic_t avflt_reply_timeout;
 extern atomic_t avflt_cache_enabled;
 extern redirfs_filter avflt;
 extern wait_queue_head_t avflt_request_available;
+
+#ifdef DEBUG
+#define avlft_pr_debug(fmt, ...) \
+	printk(KERN_INFO "avflt: %s:%d:%s:" pr_fmt(fmt) , __FILE__, __LINE__, __PRETTY_FUNCTION__, ##__VA_ARGS__)
+#else
+#define avlft_pr_debug(fmt, ...) \
+    no_printk(KERN_INFO "avflt: %s:%d:%s:" pr_fmt(fmt) , __FILE__, __LINE__, __PRETTY_FUNCTION__, ##__VA_ARGS__)
+#endif
 
 #endif
 

--- a/src/avflt/avflt_rfs.c
+++ b/src/avflt/avflt_rfs.c
@@ -23,7 +23,7 @@
 
 #include "avflt.h"
 
-static int avflt_should_check(struct file *file)
+static int avflt_should_check(struct file *file, int type)
 {
     if (avflt_is_stopped())
         return 0;
@@ -38,6 +38,9 @@ static int avflt_should_check(struct file *file)
         return 0;
 
     if (!i_size_read(file->f_dentry->d_inode))
+        return 0;
+
+    if (type == AVFLT_EVENT_CLOSE && ((file->f_flags & O_ACCMODE) == O_RDONLY))
         return 0;
 
     return 1;
@@ -119,7 +122,7 @@ static enum redirfs_rv avflt_check_file(struct file *file, int type,
 {
     int rv;
 
-    if (!avflt_should_check(file))
+    if (!avflt_should_check(file, type))
         return REDIRFS_CONTINUE;
 
     rv = avflt_check_cache(file, type);

--- a/src/avtest/avtest.c
+++ b/src/avtest/avtest.c
@@ -36,9 +36,8 @@ static int check(void)
         if (av_request(&av_conn, &av_event, 500)) {
             if (errno == ETIMEDOUT)
                 continue;
-
             perror("av_request failed");
-            return -1;
+            continue;
         }
 
         if (av_get_filename(&av_event, fn, PATH_MAX)) {
@@ -100,7 +99,7 @@ int main(int argc, char *argv[])
     sigaction(SIGINT, &sa, NULL);
 
     if (av_register(&av_conn)) {
-        perror("av_register failed");
+        perror("av_register_trusted failed");
         exit(EXIT_FAILURE);
     }
 

--- a/src/redirfs/Makefile
+++ b/src/redirfs/Makefile
@@ -2,5 +2,5 @@ obj-m += redirfs.o
 redirfs-objs := rfs_path.o rfs_root.o rfs_info.o rfs_file.o rfs_dentry.o \
 	rfs_inode.o rfs_dcache.o rfs_chain.o rfs_ops.o rfs_data.o \
 	rfs_flt.o rfs_sysfs.o rfs.o rfs_file_ops.o rfs_address_space.o  \
-	rfs_object.o rfs_hooked_ops.o
+	rfs_object.o rfs_hooked_ops.o rfs_dbg.o
 

--- a/src/redirfs/redirfs.h
+++ b/src/redirfs/redirfs.h
@@ -267,6 +267,7 @@ enum redirfs_op_idc {
 
     REDIRFS_REG_IOP_PERMISSION   = RFS_OP_IDC(RFS_INODE_REG, RFS_OP_i_permission),
     REDIRFS_REG_IOP_SETATTR      = RFS_OP_IDC(RFS_INODE_REG, RFS_OP_i_setattr),
+    REDIRFS_REG_IOP_LOOKUP      = RFS_OP_IDC(RFS_INODE_REG, RFS_OP_i_lookup),
 
     REDIRFS_DIR_IOP_CREATE       = RFS_OP_IDC(RFS_INODE_DIR, RFS_OP_i_create),
     REDIRFS_DIR_IOP_LOOKUP       = RFS_OP_IDC(RFS_INODE_DIR, RFS_OP_i_lookup),
@@ -1000,8 +1001,8 @@ struct redirfs_args {
 
 #define RFS_DEFINE_REDIRFS_ARGS(argsname) \
     struct redirfs_args argsname = { \
-            .args = (union redirfs_op_args) {0}, \
-            .rv = (union redirfs_op_rv) {0}, \
+            .args = (union redirfs_op_args) { .d_revalidate = {0} }, \
+            .rv = (union redirfs_op_rv) { .rv_dentry = NULL }, \
             .type = (struct redirfs_op_type) RFS_REDIRFS_OP_TYPE_INITIALIZER \
     }
 

--- a/src/redirfs/rfs_chain.c
+++ b/src/redirfs/rfs_chain.c
@@ -111,7 +111,7 @@ struct rfs_chain *rfs_chain_add(struct rfs_chain *rchain, struct rfs_flt *rflt)
     else
         size = rchain->rflts_nr + 1;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     rchain_new = rfs_chain_alloc(size, GFP_KERNEL);
     if (IS_ERR(rchain_new))
@@ -148,7 +148,7 @@ struct rfs_chain *rfs_chain_rem(struct rfs_chain *rchain, struct rfs_flt *rflt)
     if (rchain->rflts_nr == 1)
         return NULL;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     rchain_new = rfs_chain_alloc(rchain->rflts_nr - 1, GFP_KERNEL);
     if (IS_ERR(rchain_new))
@@ -231,7 +231,7 @@ struct rfs_chain *rfs_chain_join(struct rfs_chain *rch1, struct rfs_chain *rch2)
             size++;
     }
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     rch = rfs_chain_alloc(size, GFP_KERNEL);
     if (IS_ERR(rch))
@@ -282,7 +282,7 @@ struct rfs_chain *rfs_chain_diff(struct rfs_chain *rch1, struct rfs_chain *rch2)
     if (size == rch1->rflts_nr)
         return rfs_chain_get(rch1);
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     rch = rfs_chain_alloc(size, GFP_KERNEL);
     if (IS_ERR(rch))

--- a/src/redirfs/rfs_dbg.c
+++ b/src/redirfs/rfs_dbg.c
@@ -20,28 +20,12 @@
  * along with RedirFS. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef _RFS_DBG_H
-#define _RFS_DBG_H
+#include <linux/kernel.h>
+#include <linux/version.h>
 
-#include <asm-generic/bug.h>
-#include <linux/printk.h>
-
-#ifdef RFS_RBG_PREEMPTIBLE
-    #define rfs_preemptible() preemptible()
-    #define rfs_in_softirq() in_softirq()
-#else
-    #define rfs_preemptible() true
-    #define rfs_in_softirq() false
+#if defined RFS_DBG && defined RH_KABI_DEPRECATE && LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(3, 11, 0)
+int ____ilog2_NaN(void)
+{
+	return 0;
+}
 #endif
-
-#ifdef RFS_DBG
-    #define DBG_BUG_ON(cond) BUG_ON(cond)
-    #define rfs_pr_debug(fmt, ...) \
-	    printk(KERN_INFO "redirfs: %s:%d:%s:" pr_fmt(fmt) , __FILE__, __LINE__, __PRETTY_FUNCTION__, ##__VA_ARGS__)
-#else
-    #define DBG_BUG_ON(cond) do {} while(0)
-    #define rfs_pr_debug(fmt, ...) \
-        no_printk(KERN_INFO "redirfs: %s:%d:%s:" pr_fmt(fmt) , __FILE__, __LINE__, __PRETTY_FUNCTION__, ##__VA_ARGS__)
-#endif
-
-#endif //_RFS_DBG_H

--- a/src/redirfs/rfs_dcache.c
+++ b/src/redirfs/rfs_dcache.c
@@ -36,7 +36,7 @@ struct rfs_dcache_data *rfs_dcache_data_alloc(struct dentry *dentry,
 {
     struct rfs_dcache_data *rdata;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     rdata = kzalloc(sizeof(struct rfs_dcache_data), GFP_KERNEL);
     if (!rdata)
@@ -62,7 +62,7 @@ static struct rfs_dcache_entry *rfs_dcache_entry_alloc(struct dentry *dentry,
 {
     struct rfs_dcache_entry *entry;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     entry = kzalloc(sizeof(struct rfs_dcache_entry), GFP_KERNEL);
     if (!entry)

--- a/src/redirfs/rfs_dentry.c
+++ b/src/redirfs/rfs_dentry.c
@@ -90,7 +90,7 @@ static struct rfs_dentry *rfs_dentry_alloc(struct dentry *dentry)
 {
     struct rfs_dentry *rdentry;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     rdentry = kmem_cache_zalloc(rfs_dentry_cache, GFP_KERNEL);
     if (!rdentry)
@@ -246,6 +246,8 @@ struct rfs_dentry *rfs_dentry_add(struct dentry *dentry, struct rfs_info *rinfo)
             return ERR_PTR(err);
         }
     }
+
+    rfs_pr_debug("rd=%p, rd_new=%p", rd, rd_new);
 
     return rd;
 }
@@ -450,6 +452,7 @@ static void rfs_d_release(struct dentry *dentry)
     rfs_dentry_del(rdentry);
     rfs_dentry_put(rdentry);
     rfs_info_put(rinfo);
+    rfs_pr_debug("dentry=%p", dentry);
 }
 
 static inline int rfs_d_compare_default(const struct qstr *name1,
@@ -734,6 +737,7 @@ static int rfs_d_revalidate(struct dentry *dentry, struct nameidata *nd)
     struct rfs_dentry *rdentry;
     struct rfs_info *rinfo;
     struct rfs_context rcont;
+    struct rfs_file *rfile;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
     rdentry = rfs_dentry_find(dentry);

--- a/src/redirfs/rfs_dentry.c
+++ b/src/redirfs/rfs_dentry.c
@@ -70,9 +70,9 @@ struct rfs_dentry* rfs_dentry_find(const struct dentry *dentry)
     struct rfs_object  *robject;
 
 #ifdef RFS_PER_OBJECT_OPS
-    rinode = rfs_dentry_get(rfs_cast_to_rdentry(dentry));
-    if (rinode)
-        return rinode;
+    rdentry = rfs_dentry_get(rfs_cast_to_rdentry(dentry));
+    if (rdentry)
+        return rdentry;
 #endif /* RFS_PER_OBJECT_OPS */
 
     robject = rfs_get_object_by_system_object(&rfs_dentry_radix_tree, dentry);

--- a/src/redirfs/rfs_dentry.c
+++ b/src/redirfs/rfs_dentry.c
@@ -185,71 +185,84 @@ struct rfs_dentry *rfs_dentry_add(struct dentry *dentry, struct rfs_info *rinfo)
 {
     struct rfs_dentry *rd_new;
     struct rfs_dentry *rd = NULL;
+    int err;
 
     DBG_BUG_ON(!dentry);
     if (!dentry)
         return NULL;
 
+    spin_lock(&dentry->d_lock);
+    rd = rfs_dentry_find(dentry);
+    /*
+     * Workaround for the isofs_lookup function. It assigns
+     * dentry operations for the new dentry from the root dentry.
+     * This leads to the situation when one rdentry object can be
+     * found for more dentry objects.
+     *
+     * isofs_lookup: dentry->d_op = dir->i_sb->s_root->d_op;
+     * vfat_lookup: dentry->d_op = dir->i_sb->s_root->d_op;
+     */
+    {
+        if (rd) {
+#ifdef RFS_PER_OBJECT_OPS
+            if (rd->dentry != dentry) {
+                dentry->d_op = rd->op_old;
+                rfs_dentry_put(rd);
+            } else {
+                spin_unlock(&dentry->d_lock);
+                rfs_pr_debug("rd=%p", rd);
+                return rd;
+            }
+#else
+            spin_unlock(&dentry->d_lock);
+            rfs_pr_debug("rd=%p", rd);
+            return rd;
+#endif /* RFS_PER_OBJECT_OPS */
+        }
+#ifndef RFS_PER_OBJECT_OPS
+        if (dentry->d_op && dentry->d_op->d_iput == rfs_d_iput) {
+            if (dentry->d_sb && dentry->d_sb->s_root) {
+                rd = rfs_dentry_find(dentry->d_sb->s_root);
+                if (rd && rd->dentry != dentry) {
+                    dentry->d_op = rd->d_rhops->old.d_op;
+                    rfs_pr_debug("dentry->d_op = dentry->d_sb->s_root->d_op");
+                }
+                rfs_dentry_put(rd);
+            }
+        }
+#endif
+    }
+
     rd_new = rfs_dentry_alloc(dentry);
-    if (IS_ERR(rd_new))
+    if (IS_ERR(rd_new)) {
+        spin_unlock(&dentry->d_lock);
         return rd_new;
+    }
 
     DBG_BUG_ON(!rd_new->d_rhops);
-
-    spin_lock(&dentry->d_lock);
-    {
-        rd = rfs_dentry_find(dentry);
-
-    #ifdef RFS_PER_OBJECT_OPS
-        /*
-        * Workaround for the isofs_lookup function. It assigns
-        * dentry operations for the new dentry from the root dentry.
-        * This leads to the situation when one rdentry object can be
-        * found for more dentry objects.
-        *
-        * isofs_lookup: dentry->d_op = dir->i_sb->s_root->d_op;
-        */
-        if (rd && (rd->dentry != dentry)) {
-            rd_new->op_old = rd->op_old;
-            rfs_dentry_put(rd);
-            rd = NULL;
-        }
-    #endif /* RFS_PER_OBJECT_OPS */
-
-        if (!rd) {
-            rd_new->rinfo = rfs_info_get(rinfo);
-    #ifdef RFS_PER_OBJECT_OPS
-            dentry->d_op = &rd_new->op_new;
-    #endif /* RFS_PER_OBJECT_OPS */
-            rfs_dentry_get(rd_new);
-            rd = rfs_dentry_get(rd_new);
-        }
-    }
+    rd_new->rinfo = rfs_info_get(rinfo);
+#ifdef RFS_PER_OBJECT_OPS
+    dentry->d_op = &rd_new->op_new;
+#endif /* RFS_PER_OBJECT_OPS */
+    rfs_dentry_get(rd_new);
     spin_unlock(&dentry->d_lock);
 
-    rfs_dentry_put(rd_new);
-    
-    if (rd == rd_new) {
-        int err;
-
 #ifndef RFS_PER_OBJECT_OPS
-        rfs_keep_operations(rd->d_rhops);
+    rfs_keep_operations(rd_new->d_rhops);
 #endif /* !RFS_PER_OBJECT_OPS */
 
-        err = rfs_insert_object(&rfs_dentry_radix_tree,
-                                &rd->robject,
-                                false);
-        DBG_BUG_ON(err);
-        if (unlikely(err)) {
-            rfs_dentry_del(rd);
-            rfs_dentry_put(rd);
-            return ERR_PTR(err);
-        }
+    err = rfs_insert_object(&rfs_dentry_radix_tree,
+                            &rd_new->robject,
+                            false);
+    DBG_BUG_ON(err);
+    if (unlikely(err)) {
+        rfs_dentry_del(rd_new);
+        rfs_dentry_put(rd_new);
+        return ERR_PTR(err);
     }
 
-    rfs_pr_debug("rd=%p, rd_new=%p", rd, rd_new);
-
-    return rd;
+    rfs_pr_debug("rd_new=%p", rd_new);
+    return rd_new;
 }
 
 void rfs_dentry_del(struct rfs_dentry *rdentry)
@@ -383,7 +396,14 @@ void rfs_d_iput(struct dentry *dentry, struct inode *inode)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
+    rfs_pr_debug("dentry=%p, inode=%p", dentry, inode);
+
     rdentry = rfs_dentry_find(dentry);
+    if (!rdentry) {
+        rfs_pr_debug("dentry=%p, rdentry=%p", dentry, rdentry);
+        iput(inode);
+        return;
+    }
     rinfo = rfs_dentry_get_rinfo(rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -433,6 +453,10 @@ static void rfs_d_release(struct dentry *dentry)
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
     rdentry = rfs_dentry_find(dentry);
+    if (!rdentry) {
+        rfs_pr_debug("dentry=%p", dentry);
+        return;
+    }
     rinfo = rfs_dentry_get_rinfo(rdentry);
     rfs_context_init(&rcont, 0);
     rargs.type.id = REDIRFS_NONE_DOP_D_RELEASE;
@@ -737,7 +761,6 @@ static int rfs_d_revalidate(struct dentry *dentry, struct nameidata *nd)
     struct rfs_dentry *rdentry;
     struct rfs_info *rinfo;
     struct rfs_context rcont;
-    struct rfs_file *rfile;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
     rdentry = rfs_dentry_find(dentry);

--- a/src/redirfs/rfs_file_ops.c
+++ b/src/redirfs/rfs_file_ops.c
@@ -34,7 +34,9 @@ loff_t rfs_llseek(struct file *file, loff_t offset, int origin)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -72,7 +74,9 @@ ssize_t rfs_read(struct file *file, char __user *buf, size_t count, loff_t *pos)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -112,7 +116,9 @@ ssize_t rfs_write(struct file *file, const char __user *buf, size_t count, loff_
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -153,7 +159,9 @@ ssize_t rfs_read_iter(struct kiocb *kiocb, struct iov_iter *iov_iter)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(kiocb->ki_filp);
+    rfile = rfs_file_find_with_open_flts(kiocb->ki_filp);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -189,7 +197,9 @@ ssize_t rfs_write_iter(struct kiocb *kiocb, struct iov_iter *iov_iter)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(kiocb->ki_filp);
+    rfile = rfs_file_find_with_open_flts(kiocb->ki_filp);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -228,11 +238,14 @@ int rfs_iterate(struct file *file, struct dir_context *dir_context)
     RFS_DEFINE_REDIRFS_ARGS(rargs);
     struct dentry *d_first = NULL;
 
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
+
     /* this optimization was borrowed from
        the Kaspersky's version of rfs filter */
     d_first = rfs_get_first_cached_dir_entry(file->f_dentry);
 
-    rfile = rfs_file_find(file);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -277,11 +290,13 @@ int rfs_iterate_shared(struct file *file, struct dir_context *dir_context)
     RFS_DEFINE_REDIRFS_ARGS(rargs);
     struct dentry *d_first = NULL;
 
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     /* this optimization was borrowed from
        the Kaspersky's version of rfs filter */
     d_first = rfs_get_first_cached_dir_entry(file->f_dentry);
 
-    rfile = rfs_file_find(file);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -323,7 +338,9 @@ unsigned int rfs_poll(struct file *file, struct poll_table_struct *poll_table_st
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -359,7 +376,9 @@ long rfs_unlocked_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -397,7 +416,9 @@ long rfs_compat_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -435,7 +456,9 @@ int rfs_mmap(struct file *file, struct vm_area_struct *vma)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -471,7 +494,9 @@ int rfs_flush(struct file *file, fl_owner_t owner)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -507,7 +532,9 @@ int rfs_fsync(struct file *file, struct dentry *dentry, int datasync)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -543,7 +570,9 @@ int rfs_fsync(struct file *file, int datasync)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -577,7 +606,9 @@ int rfs_fsync(struct file *file, loff_t start, loff_t end, int datasync)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -618,7 +649,9 @@ int rfs_fsync(struct file *file, loff_t start, loff_t end, int datasync)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -656,7 +689,9 @@ int rfs_fsync(struct file *file, loff_t start, loff_t end, int datasync)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -695,7 +730,9 @@ ssize_t rfs_sendpage(struct file *file, struct page *page, int offset,
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -740,7 +777,9 @@ unsigned long rfs_get_unmapped_area(struct file *file, unsigned long addr,
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -782,7 +821,9 @@ int rfs_flock(struct file *file, int cmd, struct file_lock *flock)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -821,7 +862,9 @@ ssize_t rfs_splice_write(struct pipe_inode_info *pipe, struct file *out,
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(out);
+    rfile = rfs_file_find_with_open_flts(out);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -865,7 +908,9 @@ ssize_t rfs_splice_read(struct file *in, loff_t *ppos,
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(in);
+    rfile = rfs_file_find_with_open_flts(in);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -907,7 +952,9 @@ int rfs_setlease(struct file *file, long arg, struct file_lock **flock)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -944,7 +991,9 @@ int rfs_setlease(struct file *file, long arg, struct file_lock **flock,
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -987,7 +1036,9 @@ long rfs_fallocate(struct file *file, int mode,
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -1030,7 +1081,9 @@ int rfs_show_fdinfo(struct seq_file *seq_file, struct file *file)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -1062,7 +1115,9 @@ void rfs_show_fdinfo(struct seq_file *seq_file, struct file *file)
     struct rfs_context rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
 
-    rfile = rfs_file_find(file);
+    rfile = rfs_file_find_with_open_flts(file);
+    if (IS_ERR(rfile))
+        return;
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -1101,8 +1156,9 @@ ssize_t rfs_copy_file_range(struct file *file_in, loff_t pos_in,
 
     rfile = rfs_file_find(file_in);
     if (!rfile)
-        rfile = rfs_file_find(file_out);
-
+        rfile = rfs_file_find_with_open_flts(file_out);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -1151,8 +1207,9 @@ int rfs_clone_file_range(struct file *src_file, loff_t src_off,
 
     rfile = rfs_file_find(src_file);
     if (!rfile)
-        rfile = rfs_file_find(dst_file);
-
+        rfile = rfs_file_find_with_open_flts(dst_file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 
@@ -1198,8 +1255,9 @@ ssize_t rfs_dedupe_file_range(struct file *src_file, u64 loff,
 
     rfile = rfs_file_find(src_file);
     if (!rfile)
-        rfile = rfs_file_find(dst_file);
-
+        rfile = rfs_file_find_with_open_flts(dst_file);
+    if (IS_ERR(rfile))
+        return PTR_ERR(rfile);
     rinfo = rfs_dentry_get_rinfo(rfile->rdentry);
     rfs_context_init(&rcont, 0);
 

--- a/src/redirfs/rfs_file_ops.h
+++ b/src/redirfs/rfs_file_ops.h
@@ -23,6 +23,131 @@
 
 #include "rfs.h"
 
+#define FUNCTION_FOP_open PROTOTYPE_FOP(open, rfs_open)
+#define FUNCTION_FOP_release PROTOTYPE_FOP(release, rfs_release)
+#define FUNCTION_FOP_read PROTOTYPE_FOP(read, rfs_read)
+#define FUNCTION_FOP_write PROTOTYPE_FOP(write, rfs_write)
+#define FUNCTION_FOP_llseek PROTOTYPE_FOP(llseek, rfs_llseek)
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(3,14,0))
+    #define FUNCTION_FOP_read_iter PROTOTYPE_FOP(read_iter, rfs_read_iter)
+    #define FUNCTION_FOP_write_iter PROTOTYPE_FOP(write_iter, rfs_write_iter)
+#else
+    #define FUNCTION_FOP_read_iter
+    #define FUNCTION_FOP_write_iter
+#endif
+#define FUNCTION_FOP_poll PROTOTYPE_FOP(poll, rfs_poll)
+#define FUNCTION_FOP_unlocked_ioctl PROTOTYPE_FOP(unlocked_ioctl, rfs_unlocked_ioctl)
+#define FUNCTION_FOP_compat_ioctl PROTOTYPE_FOP(compat_ioctl, rfs_compat_ioctl)
+#define FUNCTION_FOP_mmap PROTOTYPE_FOP(mmap, rfs_mmap)
+#define FUNCTION_FOP_flush PROTOTYPE_FOP(flush, rfs_flush)
+#define FUNCTION_FOP_fsync PROTOTYPE_FOP(fsync, rfs_fsync)
+#define FUNCTION_FOP_fasync PROTOTYPE_FOP(fasync, rfs_fasync)
+#define FUNCTION_FOP_lock PROTOTYPE_FOP(lock, rfs_lock)
+#define FUNCTION_FOP_sendpage PROTOTYPE_FOP(sendpage, rfs_sendpage)
+#define FUNCTION_FOP_get_unmapped_area PROTOTYPE_FOP(get_unmapped_area, rfs_get_unmapped_area)
+#define FUNCTION_FOP_flock PROTOTYPE_FOP(flock, rfs_flock)
+#define FUNCTION_FOP_splice_write PROTOTYPE_FOP(splice_write, rfs_splice_write)
+#define FUNCTION_FOP_splice_read PROTOTYPE_FOP(splice_read, rfs_splice_read)
+#define FUNCTION_FOP_setlease PROTOTYPE_FOP(setlease, rfs_setlease)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,38))
+    #define FUNCTION_FOP_fallocate PROTOTYPE_FOP(fallocate, rfs_fallocate)
+#else
+    #define FUNCTION_FOP_fallocate
+#endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,8,0))
+    #define FUNCTION_FOP_show_fdinfo PROTOTYPE_FOP(show_fdinfo, rfs_show_fdinfo)
+#else
+    #define FUNCTION_FOP_show_fdinfo
+#endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,5,0))
+    #define FUNCTION_FOP_copy_file_range PROTOTYPE_FOP(copy_file_range, rfs_copy_file_range)
+    #define FUNCTION_FOP_clone_file_range PROTOTYPE_FOP(clone_file_range, rfs_clone_file_range)
+    #define FUNCTION_FOP_dedupe_file_range PROTOTYPE_FOP(dedupe_file_range, rfs_dedupe_file_range)
+#else
+    #define FUNCTION_FOP_copy_file_range
+    #define FUNCTION_FOP_clone_file_range
+    #define FUNCTION_FOP_dedupe_file_range
+#endif
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,11,0))
+#define FUNCTION_FOP_readdir PROTOTYPE_FOP(readdir, rfs_readdir)
+#define FUNCTION_FOP_iterate
+#else
+#define FUNCTION_FOP_readdir
+#define FUNCTION_FOP_iterate PROTOTYPE_FOP(iterate, rfs_iterate)
+#endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0))
+#define FUNCTION_FOP_iterate_shared PROTOTYPE_FOP(iterate_shared, rfs_iterate_shared)
+#else
+#define FUNCTION_FOP_iterate_shared
+#endif
+
+#ifdef RFS_PER_OBJECT_OPS 
+/*
+ * the open opeartion is called through rfile->op_new.open registered on inode lookup
+ * then unconditionally set for file_operations and should not be removed as used as
+ * a watermark for rfs_cast_to_rfile
+ *
+ * FUNCTION_FOP_open
+ */
+#endif
+
+#define SET_FOP_REG \
+    FUNCTION_FOP_read \
+    FUNCTION_FOP_write \
+    FUNCTION_FOP_llseek \
+    FUNCTION_FOP_read_iter \
+    FUNCTION_FOP_write_iter \
+    FUNCTION_FOP_poll \
+    FUNCTION_FOP_unlocked_ioctl \
+    FUNCTION_FOP_compat_ioctl \
+    FUNCTION_FOP_mmap \
+    FUNCTION_FOP_flush \
+    FUNCTION_FOP_fsync \
+    FUNCTION_FOP_fasync \
+    FUNCTION_FOP_lock \
+    FUNCTION_FOP_sendpage \
+    FUNCTION_FOP_get_unmapped_area \
+    FUNCTION_FOP_flock \
+    FUNCTION_FOP_splice_write \
+    FUNCTION_FOP_splice_read \
+    FUNCTION_FOP_setlease \
+    FUNCTION_FOP_fallocate \
+    FUNCTION_FOP_show_fdinfo \
+    FUNCTION_FOP_copy_file_range \
+    FUNCTION_FOP_clone_file_range \
+    FUNCTION_FOP_dedupe_file_range \
+
+#define SET_FOP_DIR \
+    FUNCTION_FOP_readdir \
+    FUNCTION_FOP_iterate \
+    FUNCTION_FOP_iterate_shared \
+
+#define SET_FOP_CHR \
+    FUNCTION_FOP_read \
+    FUNCTION_FOP_write \
+    FUNCTION_FOP_llseek \
+    FUNCTION_FOP_read_iter \
+    FUNCTION_FOP_write_iter \
+    FUNCTION_FOP_poll \
+    FUNCTION_FOP_unlocked_ioctl \
+    FUNCTION_FOP_compat_ioctl \
+    FUNCTION_FOP_mmap \
+    FUNCTION_FOP_flush \
+    FUNCTION_FOP_fsync \
+    FUNCTION_FOP_fasync \
+    FUNCTION_FOP_lock \
+    FUNCTION_FOP_sendpage \
+    FUNCTION_FOP_get_unmapped_area \
+    FUNCTION_FOP_flock \
+    FUNCTION_FOP_splice_write \
+    FUNCTION_FOP_splice_read \
+    FUNCTION_FOP_setlease \
+    FUNCTION_FOP_fallocate \
+    FUNCTION_FOP_show_fdinfo \
+    FUNCTION_FOP_copy_file_range \
+    FUNCTION_FOP_clone_file_range \
+    FUNCTION_FOP_dedupe_file_range \
+
 loff_t rfs_llseek(struct file *file,
                   loff_t offset,
                   int origin);
@@ -154,5 +279,11 @@ ssize_t rfs_dedupe_file_range(struct file *src_file,
                               u64 len,
                               struct file *dst_file,
                               u64 dst_loff);
+
+int rfs_release(struct inode *inode, struct file *file);
+
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,11,0))
+int rfs_readdir(struct file *file, void *dirent, filldir_t filldir);
+#endif
 
 #endif // _RFS_FILE_OPS_H

--- a/src/redirfs/rfs_hooked_ops.c
+++ b/src/redirfs/rfs_hooked_ops.c
@@ -216,7 +216,7 @@ rfs_create_file_ops(
     struct rfs_hoperations  *rhoperations = NULL;
     size_t                  size;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
     DBG_BUG_ON(!op_old);
     if (!op_old)
         return NULL;
@@ -302,7 +302,7 @@ rfs_create_inode_ops(
     struct rfs_hoperations  *rhoperations = NULL;
     size_t                  size;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
     DBG_BUG_ON(!op_old);
     if (!op_old)
         return ERR_PTR(-EINVAL); 
@@ -380,7 +380,7 @@ rfs_create_address_space_ops(
     struct rfs_hoperations  *rhoperations = NULL;
     size_t                  size;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
     DBG_BUG_ON(!op_old);
     if (!op_old)
         return ERR_PTR(-EINVAL); 
@@ -458,7 +458,7 @@ rfs_create_dentry_ops(
     struct rfs_hoperations  *rhoperations = NULL;
     size_t                  size;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     /* op_old might be NULL for some dentries */
     rhoperations = rfs_find_operations(rfs_hoperations_radix_tree[RFS_TYPE_DENTRY_OPS],

--- a/src/redirfs/rfs_info.c
+++ b/src/redirfs/rfs_info.c
@@ -56,7 +56,7 @@ struct rfs_info *rfs_info_alloc(struct rfs_root *rroot,
     struct rfs_info *rinfo;
     int rv;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     rinfo = kzalloc(sizeof(struct rfs_info), GFP_KERNEL);
     if (!rinfo)

--- a/src/redirfs/rfs_inode.c
+++ b/src/redirfs/rfs_inode.c
@@ -31,6 +31,7 @@
 #include "rfs.h"
 #include "rfs_address_space.h"
 #include "rfs_hooked_ops.h"
+#include "rfs_file_ops.h"
 
 #ifdef RFS_DBG
     #pragma GCC push_options
@@ -98,7 +99,7 @@ static struct rfs_inode *rfs_inode_alloc(struct inode *inode)
 {
     struct rfs_inode *rinode;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     rinode = kmem_cache_zalloc(rfs_inode_cache, GFP_KERNEL);
     if (IS_ERR(rinode))
@@ -209,6 +210,97 @@ void rfs_inode_free(struct rfs_object *robject)
 
 /*---------------------------------------------------------------------------*/
 
+static void rfs_inode_set_default_fop_reg(struct rfs_inode *ri_new, struct inode *inode)
+{
+#define PROTOTYPE_FOP(op, new_op) \
+    RFS_ADD_OP(ri_new->f_op_new, inode->i_fop, op, new_op);
+    FUNCTION_FOP_open
+        SET_FOP_REG
+#undef PROTOTYPE_FOP
+}
+
+static void rfs_inode_set_default_fop_dir(struct rfs_inode *ri_new, struct inode *inode)
+{
+#define PROTOTYPE_FOP(op, new_op) \
+    RFS_ADD_OP(ri_new->f_op_new, inode->i_fop, op, new_op);
+    FUNCTION_FOP_open
+        SET_FOP_DIR
+#undef PROTOTYPE_FOP
+}
+
+static void rfs_inode_set_default_fop_lnk(struct rfs_inode *ri_new, struct inode *inode)
+{
+#define PROTOTYPE_FOP(op, new_op) \
+    RFS_ADD_OP_MGT(ri_new->f_op_new, inode->i_fop, op, new_op);
+    FUNCTION_FOP_open
+#undef PROTOTYPE_FOP
+}
+
+static void rfs_inode_set_default_fop_chr(struct rfs_inode *ri_new, struct inode *inode)
+{
+#define PROTOTYPE_FOP(op, new_op) \
+    RFS_ADD_OP(ri_new->f_op_new, inode->i_fop, op, new_op);
+    FUNCTION_FOP_open
+    SET_FOP_CHR
+#undef PROTOTYPE_FOP
+}
+
+static void rfs_inode_set_default_fop_blk(struct rfs_inode *ri_new, struct inode *inode)
+{
+#define PROTOTYPE_FOP(op, new_op) \
+    RFS_ADD_OP_MGT(ri_new->f_op_new, inode->i_fop, op, new_op);
+    FUNCTION_FOP_open
+#undef PROTOTYPE_FOP
+}
+
+static void rfs_inode_set_default_fop_fifo(struct rfs_inode *ri_new, struct inode *inode)
+{
+#define PROTOTYPE_FOP(op, new_op) \
+    RFS_ADD_OP_MGT(ri_new->f_op_new, inode->i_fop, op, new_op);
+    FUNCTION_FOP_open
+#undef PROTOTYPE_FOP
+}
+
+static void rfs_inode_set_default_fop(struct rfs_inode *ri_new, struct inode *inode)
+{
+    umode_t mode = inode->i_mode;
+
+    if (S_ISREG(mode))
+        rfs_inode_set_default_fop_reg(ri_new, inode);
+
+    else if (S_ISDIR(mode))
+        rfs_inode_set_default_fop_dir(ri_new, inode);
+
+    else if (S_ISLNK(mode))
+        rfs_inode_set_default_fop_lnk(ri_new, inode);
+
+    else if (S_ISCHR(mode))
+        rfs_inode_set_default_fop_chr(ri_new, inode);
+
+    else if (S_ISBLK(mode))
+        rfs_inode_set_default_fop_blk(ri_new, inode);
+
+    else if (S_ISFIFO(mode))
+        rfs_inode_set_default_fop_fifo(ri_new, inode);
+
+    else if (S_ISSOCK(mode))
+    {
+        /*
+         * nothing
+         */
+        return;
+    }
+
+    #define PROTOTYPE_FOP(op, new_op) \
+    RFS_ADD_OP_MGT(ri_new->f_op_new, inode->i_fop, op, new_op);
+    FUNCTION_FOP_release
+    #undef PROTOTYPE_FOP
+
+    inode->i_fop = &ri_new->f_op_new;
+}
+
+/*---------------------------------------------------------------------------*/
+
 struct rfs_inode *rfs_inode_add(struct inode *inode, struct rfs_info *rinfo)
 {
     struct rfs_inode *ri_new;
@@ -228,19 +320,11 @@ struct rfs_inode *rfs_inode_add(struct inode *inode, struct rfs_info *rinfo)
     {
         ri = rfs_inode_find(inode);
         if (!ri) {
-
             DBG_BUG_ON(ri_new->f_op_old->open == rfs_open);
 
             ri_new->rinfo = rfs_info_get(rinfo);
 
-            /*
-             * unconditionally register open operation to be notified
-             * of open requests, some devices do not register open
-             * operation, e.g. null_fops, but RedirFS requires
-             * open operation to be called through file_operations
-             */
-            if (!S_ISSOCK(inode->i_mode))
-                inode->i_fop = &rfs_file_ops;
+            rfs_inode_set_default_fop(ri_new, inode);
 
 #ifdef RFS_PER_OBJECT_OPS
             inode->i_op = &ri_new->op_new;
@@ -481,19 +565,82 @@ void rfs_inode_cache_destroy(void)
     kmem_cache_destroy(rfs_inode_cache);
 }
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,6,0))
-static struct dentry *rfs_lookup(struct inode *dir, struct dentry *dentry,
-        struct nameidata *nd)
-#else
-static struct dentry *rfs_lookup(struct inode *dir, struct dentry *dentry,
-        unsigned int flags)
-#endif
+static int is_fs_with_name(const char* name, struct inode *dir)
 {
-    struct rfs_inode *rinode;
-    struct rfs_info *rinfo;
-    struct rfs_context rcont;
+    if (dir && dir->i_sb && dir->i_sb->s_type && dir->i_sb->s_type->name) {
+        rfs_pr_debug("name=%s", dir->i_sb->s_type->name);
+        return !strcmp(name, dir->i_sb->s_type->name);
+    }
+    return 0;
+}
+
+static int lookup_cifs_rfs_dcache_rdentry_add(unsigned int flags, struct dentry *dentry, struct rfs_info *rinfo)
+{
+	/*
+	 * If dentry->d_inode doesn't exist and dentry wants to be exclusive created, then it
+	 * will be handled by rfs_create. Create of FS can override dentry
+	 * operation(d_op). eg: CIFS
+	 */
+
+	if ((flags & LOOKUP_OPEN) && !(flags & LOOKUP_EXCL)) {
+		if (rfs_dcache_rdentry_add(dentry, rinfo))
+			BUG();
+        return 0;
+	}
+    return -1;
+}
+
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,6,0))
+
+static void rfs_lookup_add_nameidata(struct dentry *dentry, struct nameidata *nd)
+{
+    struct file         *file;
+    struct rfs_file     *rfile;
+
+	if (nd && nd->flags & LOOKUP_OPEN) {
+		file = !IS_ERR(nd->intent.open.file) ? nd->intent.open.file : NULL;
+		rfs_pr_debug("file(%p)->f_dentry(%p)->d_inode(%p), dentry(%p)->d_inode(%p)",
+					 file,
+					 file ? file->f_dentry : NULL,
+					 file && file->f_dentry ? file->f_dentry->d_inode : NULL,
+					 dentry,
+					 dentry->d_inode);
+		if (file && (file->f_dentry == dentry) && (file->f_dentry->d_inode && dentry->d_inode)) {
+			/*
+			 * File was open and can be used by f_op -> register it to rfs.
+			 * e.g: NFS first open of file
+			 */
+
+			if (S_ISREG(nd->intent.open.file->f_mode)) {
+				/*
+				 * Emulate open operation for redirfs filters.
+				 */
+				rfile = rfs_file_find_with_open_flts(file);
+				if (IS_ERR(rfile)) {
+					d_drop(dentry);
+					dentry = (struct dentry *)rfile;
+				}
+			} else {
+				rfile = rfs_file_add(file);
+				if (IS_ERR(rfile))
+					BUG();
+			}
+			rfs_file_put(rfile);
+		}
+	}
+}
+
+struct dentry *rfs_lookup(struct inode *dir, struct dentry *dentry,
+        struct nameidata *nd)
+{
+    struct rfs_inode    *rinode;
+    struct rfs_info     *rinfo;
+    struct rfs_context   rcont;
     RFS_DEFINE_REDIRFS_ARGS(rargs);
-    struct dentry *dadd = dentry;
+
+    rfs_pr_debug("dir=%p, dentry=%p, nameidata=%p", dir, dentry, nd);
+    if (nd)
+        rfs_pr_debug("nd: { flags: 0x%x, intent.open: { flags: 0x%x, create_mode: 0x%x }}", nd->flags, nd->intent.open.flags, nd->intent.open.create_mode);
 
     if (S_ISDIR(dir->i_mode))
         rargs.type.id = REDIRFS_DIR_IOP_LOOKUP;
@@ -506,28 +653,17 @@ static struct dentry *rfs_lookup(struct inode *dir, struct dentry *dentry,
 
     rargs.args.i_lookup.dir = dir;
     rargs.args.i_lookup.dentry = dentry;
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,6,0))
     rargs.args.i_lookup.nd = nd;
-#else
-    rargs.args.i_lookup.flags = flags;
-#endif
+
     rargs.rv.rv_dentry = ERR_PTR(-ENOSYS);
 
     if (!RFS_IS_IOP_SET(rinode, rargs.type.id) ||
         !rfs_precall_flts(rinfo->rchain, &rcont, &rargs)) {
         if (rinode->op_old && rinode->op_old->lookup) {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,6,0))
             rargs.rv.rv_dentry = rinode->op_old->lookup(
                     rargs.args.i_lookup.dir,
                     rargs.args.i_lookup.dentry,
                     rargs.args.i_lookup.nd);
-#else
-            rargs.rv.rv_dentry = rinode->op_old->lookup(
-                    rargs.args.i_lookup.dir,
-                    rargs.args.i_lookup.dentry,
-                    rargs.args.i_lookup.flags);
-
-#endif
         }
     }
 
@@ -539,16 +675,89 @@ static struct dentry *rfs_lookup(struct inode *dir, struct dentry *dentry,
     if (IS_ERR(rargs.rv.rv_dentry))
         goto exit;
 
-    if (rargs.rv.rv_dentry)
-        dadd = rargs.rv.rv_dentry;
-
-    if (rfs_dcache_rdentry_add(dadd, rinfo))
-        BUG();
+	if (is_fs_with_name("cifs", dir)) {
+        if (nd) {
+            if (!lookup_cifs_rfs_dcache_rdentry_add(nd->flags, dentry, rinfo) && (nd->flags & LOOKUP_CREATE)) {
+                rfs_lookup_add_nameidata(dentry, nd);
+			}
+		}
+	} else {
+		if (rargs.rv.rv_dentry)
+			dentry = rargs.rv.rv_dentry;
+		if (rfs_dcache_rdentry_add(dentry, rinfo))
+			BUG();
+	}
 exit:
     rfs_inode_put(rinode);
     rfs_info_put(rinfo);
+    rfs_pr_debug("dentry=%p, ret=%ld", dentry, IS_ERR(dentry) ? PTR_ERR(dentry) : 0);
     return rargs.rv.rv_dentry;
 }
+
+#else
+
+static struct dentry *rfs_lookup(struct inode *dir, struct dentry *dentry,
+        unsigned int flags)
+{
+    struct rfs_inode *rinode;
+    struct rfs_info *rinfo;
+    struct rfs_context rcont;
+
+    RFS_DEFINE_REDIRFS_ARGS(rargs);
+
+    rfs_pr_debug("dir=%p, dentry=%p, flags=0x%x", dir, dentry, flags);
+
+    if (S_ISDIR(dir->i_mode))
+        rargs.type.id = REDIRFS_DIR_IOP_LOOKUP;
+    else
+        return ERR_PTR(-ENOTDIR);
+
+    rinode = rfs_inode_find(dir);
+    rinfo = rfs_inode_get_rinfo(rinode);
+    rfs_context_init(&rcont, 0);
+
+    rargs.args.i_lookup.dir = dir;
+    rargs.args.i_lookup.dentry = dentry;
+    rargs.args.i_lookup.flags = flags;
+
+    rargs.rv.rv_dentry = ERR_PTR(-ENOSYS);
+
+    if (!RFS_IS_IOP_SET(rinode, rargs.type.id) ||
+        !rfs_precall_flts(rinfo->rchain, &rcont, &rargs)) {
+        if (rinode->op_old && rinode->op_old->lookup) {
+            rargs.rv.rv_dentry = rinode->op_old->lookup(
+                    rargs.args.i_lookup.dir,
+                    rargs.args.i_lookup.dentry,
+                    rargs.args.i_lookup.flags);
+        }
+    }
+
+    if (RFS_IS_IOP_SET(rinode, rargs.type.id))
+        rfs_postcall_flts(rinfo->rchain, &rcont, &rargs);
+
+    rfs_context_deinit(&rcont);
+
+    if (IS_ERR(rargs.rv.rv_dentry))
+        goto exit;
+
+    if (is_fs_with_name("cifs", dir)) {
+		lookup_cifs_rfs_dcache_rdentry_add(flags, dentry, rinfo);
+    } else {
+        if (rargs.rv.rv_dentry)
+            dentry = rargs.rv.rv_dentry;
+        if (rfs_dcache_rdentry_add(dentry, rinfo))
+            BUG();
+    }
+
+exit:
+    rfs_inode_put(rinode);
+    rfs_info_put(rinfo);
+
+    rfs_pr_debug("dentry=%p, ret=%ld", dentry, IS_ERR(rargs.rv.rv_dentry) ? PTR_ERR(rargs.rv.rv_dentry) : 0);
+    return rargs.rv.rv_dentry;
+}
+
+#endif
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3,3,0))
 static int rfs_mkdir(struct inode *dir, struct dentry *dentry, int mode)
@@ -600,12 +809,89 @@ static int rfs_mkdir(struct inode *dir, struct dentry *dentry, umode_t mode)
 }
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3,6,0))
+
 static int rfs_create(struct inode *dir, struct dentry *dentry, int mode,
         struct nameidata *nd)
+{
+    struct rfs_file     *rfile;
+    struct file         *file;
+    struct rfs_inode    *rinode;
+    struct rfs_info     *rinfo;
+    struct rfs_context   rcont;
+    RFS_DEFINE_REDIRFS_ARGS(rargs);
+
+    rfs_pr_debug("dir=%p, dentry=%p, mode=%d, nameidata=%p",
+        dir, dentry, mode, nd);
+    if (nd)
+        rfs_pr_debug("nd: { flags: 0x%x, intent.open: { flags: 0x%x, create_mode: 0x%x }}", nd->flags, nd->intent.open.flags, nd->intent.open.create_mode);
+
+    rinode = rfs_inode_find(dir);
+    rinfo = rfs_inode_get_rinfo(rinode);
+    rfs_context_init(&rcont, 0);
+
+    if (S_ISDIR(dir->i_mode))
+        rargs.type.id = REDIRFS_DIR_IOP_CREATE;
+    else
+        BUG();
+
+    rargs.args.i_create.dir = dir;
+    rargs.args.i_create.dentry = dentry;
+    rargs.args.i_create.mode = mode;
+    rargs.args.i_create.nd = nd;
+
+    rargs.rv.rv_int = -ENOSYS;
+
+    if (!RFS_IS_IOP_SET(rinode, rargs.type.id) ||
+        !rfs_precall_flts(rinfo->rchain, &rcont, &rargs)) {
+        if (rinode->op_old && rinode->op_old->create) {
+            rargs.rv.rv_int = rinode->op_old->create(
+                    rargs.args.i_create.dir,
+                    rargs.args.i_create.dentry,
+                    rargs.args.i_create.mode,
+                    rargs.args.i_create.nd);
+        }
+    }
+
+    if (RFS_IS_IOP_SET(rinode, rargs.type.id))
+        rfs_postcall_flts(rinfo->rchain, &rcont, &rargs);
+
+    rfs_context_deinit(&rcont);
+
+	if (!rargs.rv.rv_int && dentry) {
+		if (rfs_dcache_rdentry_add(dentry, rinfo))
+			BUG();
+		if (nd && !IS_ERR(nd->intent.open.file) && nd->intent.open.file && dentry == nd->intent.open.file->f_dentry) {
+			/*
+			 * Empty file was created and can be used by f_op -> register it to rfs.
+			 */
+			file = nd->intent.open.file;
+			rfs_pr_debug("flags=0x%x, open_flags=0x%x, "
+						 "file(%p)->f_dentry(%p)->d_inode(%p), dentry(%p)->d_inode(%p)",
+						 nd->flags,
+						 nd->intent.open.flags,
+						 file,
+						 file->f_dentry,
+						 file->f_dentry->d_inode,
+						 dentry,
+						 dentry->d_inode);
+			rfile = rfs_file_add(file);
+			if (IS_ERR(rfile))
+				BUG();
+			rfs_file_put(rfile);
+		}
+	}
+
+	rfs_inode_put(rinode);
+    rfs_info_put(rinfo);
+
+    rfs_pr_debug("dentry=%p, ret=%d", dentry, rargs.rv.rv_int);
+    return rargs.rv.rv_int;
+}
+
 #else
+
 static int rfs_create(struct inode *dir, struct dentry *dentry, umode_t mode,
         bool excl)
-#endif
 {
     struct rfs_inode *rinode;
     struct rfs_info *rinfo;
@@ -624,29 +910,18 @@ static int rfs_create(struct inode *dir, struct dentry *dentry, umode_t mode,
     rargs.args.i_create.dir = dir;
     rargs.args.i_create.dentry = dentry;
     rargs.args.i_create.mode = mode;
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,6,0))
-    rargs.args.i_create.nd = nd;
-#else
     rargs.args.i_create.excl = excl;
-#endif
+
     rargs.rv.rv_int = -ENOSYS;
 
     if (!RFS_IS_IOP_SET(rinode, rargs.type.id) ||
         !rfs_precall_flts(rinfo->rchain, &rcont, &rargs)) {
         if (rinode->op_old && rinode->op_old->create) {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,6,0))
-            rargs.rv.rv_int = rinode->op_old->create(
-                    rargs.args.i_create.dir,
-                    rargs.args.i_create.dentry,
-                    rargs.args.i_create.mode,
-                    rargs.args.i_create.nd);
-#else
             rargs.rv.rv_int = rinode->op_old->create(
                     rargs.args.i_create.dir,
                     rargs.args.i_create.dentry,
                     rargs.args.i_create.mode,
                     rargs.args.i_create.excl);
-#endif
         }
     }
 
@@ -657,13 +932,17 @@ static int rfs_create(struct inode *dir, struct dentry *dentry, umode_t mode,
 
     if (!rargs.rv.rv_int) {
         if (rfs_dcache_rdentry_add(dentry, rinfo))
-            BUG();
+          BUG();
     }
 
     rfs_inode_put(rinode);
     rfs_info_put(rinfo);
+
+    rfs_pr_debug("dentry=%p, ret=%d", dentry, rargs.rv.rv_int);
     return rargs.rv.rv_int;
 }
+
+#endif
 
 static int rfs_link(struct dentry *old_dentry, struct inode *dir,
         struct dentry *dentry)
@@ -845,6 +1124,7 @@ static int rfs_unlink(struct inode *inode, struct dentry *dentry)
 
     rfs_inode_put(rinode);
     rfs_info_put(rinfo);
+    rfs_pr_debug("dentry=%p, ret=%d", dentry, rargs.rv.rv_int);
     return rargs.rv.rv_int;
 }
 
@@ -1476,6 +1756,8 @@ int rfs_atomic_open(struct inode *inode, struct dentry *dentry, struct file *fil
 
     rfs_inode_put(rinode);
     rfs_info_put(rinfo);
+
+    rfs_pr_debug("dentry=%p, ret=%d", dentry, rargs.rv.rv_int);
     return rargs.rv.rv_int;
 }
 #endif
@@ -1568,7 +1850,6 @@ void rfs_inode_set_ops(struct rfs_inode *rinode)
         if (S_ISREG(mode)) {
             rfs_inode_set_ops_reg(rinode);
             rfs_inode_set_aops_reg(rinode);
-
         } else if (S_ISDIR(mode))
             rfs_inode_set_ops_dir(rinode);
 

--- a/src/redirfs/rfs_inode.c
+++ b/src/redirfs/rfs_inode.c
@@ -214,8 +214,7 @@ static void rfs_inode_set_default_fop_reg(struct rfs_inode *ri_new, struct inode
 {
 #define PROTOTYPE_FOP(op, new_op) \
     RFS_ADD_OP(ri_new->f_op_new, inode->i_fop, op, new_op);
-    FUNCTION_FOP_open
-        SET_FOP_REG
+    SET_FOP_REG
 #undef PROTOTYPE_FOP
 }
 
@@ -223,42 +222,28 @@ static void rfs_inode_set_default_fop_dir(struct rfs_inode *ri_new, struct inode
 {
 #define PROTOTYPE_FOP(op, new_op) \
     RFS_ADD_OP(ri_new->f_op_new, inode->i_fop, op, new_op);
-    FUNCTION_FOP_open
-        SET_FOP_DIR
+    SET_FOP_DIR
 #undef PROTOTYPE_FOP
 }
 
 static void rfs_inode_set_default_fop_lnk(struct rfs_inode *ri_new, struct inode *inode)
 {
-#define PROTOTYPE_FOP(op, new_op) \
-    RFS_ADD_OP_MGT(ri_new->f_op_new, inode->i_fop, op, new_op);
-    FUNCTION_FOP_open
-#undef PROTOTYPE_FOP
 }
 
 static void rfs_inode_set_default_fop_chr(struct rfs_inode *ri_new, struct inode *inode)
 {
 #define PROTOTYPE_FOP(op, new_op) \
     RFS_ADD_OP(ri_new->f_op_new, inode->i_fop, op, new_op);
-    FUNCTION_FOP_open
     SET_FOP_CHR
 #undef PROTOTYPE_FOP
 }
 
 static void rfs_inode_set_default_fop_blk(struct rfs_inode *ri_new, struct inode *inode)
 {
-#define PROTOTYPE_FOP(op, new_op) \
-    RFS_ADD_OP_MGT(ri_new->f_op_new, inode->i_fop, op, new_op);
-    FUNCTION_FOP_open
-#undef PROTOTYPE_FOP
 }
 
 static void rfs_inode_set_default_fop_fifo(struct rfs_inode *ri_new, struct inode *inode)
 {
-#define PROTOTYPE_FOP(op, new_op) \
-    RFS_ADD_OP_MGT(ri_new->f_op_new, inode->i_fop, op, new_op);
-    FUNCTION_FOP_open
-#undef PROTOTYPE_FOP
 }
 
 static void rfs_inode_set_default_fop(struct rfs_inode *ri_new, struct inode *inode)
@@ -291,10 +276,11 @@ static void rfs_inode_set_default_fop(struct rfs_inode *ri_new, struct inode *in
         return;
     }
 
-    #define PROTOTYPE_FOP(op, new_op) \
+#define PROTOTYPE_FOP(op, new_op) \
     RFS_ADD_OP_MGT(ri_new->f_op_new, inode->i_fop, op, new_op);
+    FUNCTION_FOP_open // a watermark for rfs_cast_to_rfile
     FUNCTION_FOP_release
-    #undef PROTOTYPE_FOP
+#undef PROTOTYPE_FOP
 
     inode->i_fop = &ri_new->f_op_new;
 }
@@ -1802,7 +1788,7 @@ static void rfs_inode_set_ops_dir(struct rfs_inode *rinode)
     RFS_SET_IOP_MGT(rinode, REDIRFS_DIR_IOP_MKDIR, mkdir, rfs_mkdir);
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(3,5,0))
     // hook atomic_open when i_op has it
-    if (rinode->i_rhops->old.i_op->atomic_open)
+    if (rinode->op_old->atomic_open)
         RFS_SET_IOP_MGT(rinode, REDIRFS_DIR_IOP_ATOMIC_OPEN, atomic_open, rfs_atomic_open);
 #endif
 }

--- a/src/redirfs/rfs_inode.c
+++ b/src/redirfs/rfs_inode.c
@@ -1384,7 +1384,7 @@ static int rfs_setattr_default(struct dentry *dentry, struct iattr *iattr)
     struct inode *inode = dentry->d_inode;
     int rv;
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,9,0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,9,0) && !(LINUX_VERSION_CODE > KERNEL_VERSION(3,16,38) && LINUX_VERSION_CODE < KERNEL_VERSION(3,17,0)))
     rv = inode_change_ok(inode, iattr);
 #else
     rv = setattr_prepare(dentry, iattr);

--- a/src/redirfs/rfs_object.c
+++ b/src/redirfs/rfs_object.c
@@ -186,7 +186,7 @@ int rfs_insert_object(
     rfs_object->object_table = rfs_object_table;
 
     /* spin_lock can't synchronize user context with softirq */
-    DBG_BUG_ON(in_softirq());
+    DBG_BUG_ON(rfs_in_softirq());
 
     spin_lock(&table_entry->lock);
     { /* start of the lock */
@@ -248,7 +248,7 @@ rfs_remove_object(
     rcu_assign_pointer(rfs_object->system_object, NULL);
 
     /* spin_lock can't synchronize user context with softirq */
-    DBG_BUG_ON(in_softirq());
+    DBG_BUG_ON(rfs_in_softirq());
 
     spin_lock(&table_entry->lock);
     { /* start of the lock */
@@ -278,7 +278,7 @@ rfs_get_object_by_system_object(
     DBG_BUG_ON(!system_object && radix_tree->rfs_type != RFS_TYPE_DENTRY_OPS);
 
     /* spin_lock can't synchronize user context with softirq */
-    DBG_BUG_ON(in_softirq());
+    DBG_BUG_ON(rfs_in_softirq());
 
     rcu_read_lock();
     { /* start of the RCU lock */
@@ -299,7 +299,7 @@ int rfs_insert_object(
     int    err;
 
     do {
-        DBG_BUG_ON(!preemptible());
+        DBG_BUG_ON(!rfs_preemptible());
         err = radix_tree_preload(GFP_KERNEL);
         {
             DBG_BUG_ON(err);
@@ -313,7 +313,7 @@ int rfs_insert_object(
                 rfs_object->radix_tree = radix_tree;
 
                 /* spin_lock can't synchronize user context with softirq */
-                DBG_BUG_ON(in_softirq());
+                DBG_BUG_ON(rfs_in_softirq());
 
                 spin_lock(&radix_tree->lock);
                 {
@@ -384,7 +384,7 @@ rfs_remove_object(
         bool removed;
 
         /* spin_lock can't synchronize user context with softirq */
-        DBG_BUG_ON(in_softirq());
+        DBG_BUG_ON(rfs_in_softirq());
 
         spin_lock(&radix_tree->lock);
         {

--- a/src/redirfs/rfs_ops.c
+++ b/src/redirfs/rfs_ops.c
@@ -38,7 +38,7 @@ struct rfs_ops *rfs_ops_alloc(void)
 {
     struct rfs_ops *rops;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     rops = kzalloc(sizeof(struct rfs_ops), GFP_KERNEL);
     WARN_ON(!rops);

--- a/src/redirfs/rfs_path.c
+++ b/src/redirfs/rfs_path.c
@@ -42,7 +42,7 @@ static struct rfs_path *rfs_path_alloc(struct vfsmount *mnt,
     size_t size;
     char* pathname;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     rpath = kzalloc(sizeof(struct rfs_path), GFP_KERNEL);
     if (!rpath)
@@ -505,7 +505,7 @@ redirfs_path* redirfs_get_paths_root(redirfs_filter filter, redirfs_root root)
     redirfs_path *paths;
     int i = 0;
     
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     if (!filter || IS_ERR(filter) || !root)
         return ERR_PTR(-EINVAL);
@@ -540,7 +540,7 @@ redirfs_path* redirfs_get_paths(redirfs_filter filter)
     redirfs_path *paths;
     int i = 0;
     
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
     might_sleep();
 
     if (!filter || IS_ERR(filter))
@@ -590,7 +590,7 @@ struct redirfs_path_info *redirfs_get_path_info(redirfs_filter filter,
     struct rfs_path *rpath = path;
     struct redirfs_path_info *info;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
     might_sleep();
 
     if (!filter || IS_ERR(filter) || !path)
@@ -664,7 +664,7 @@ int rfs_path_get_info(struct rfs_flt *rflt, char *buf, int size)
     char type;
     int len = 0;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     rfs_mutex_lock(&rfs_path_mutex);
 

--- a/src/redirfs/rfs_root.c
+++ b/src/redirfs/rfs_root.c
@@ -38,7 +38,7 @@ static struct rfs_root *rfs_root_alloc(struct dentry *dentry)
 {
     struct rfs_root *rroot;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     rroot = kzalloc(sizeof(struct rfs_root), GFP_KERNEL);
     if (!rroot)

--- a/src/redirfs/rfs_sysfs.c
+++ b/src/redirfs/rfs_sysfs.c
@@ -159,7 +159,7 @@ static int rfs_flt_paths_add(redirfs_filter filter, const char *buf,
     char type;
     int rv;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     path = kzalloc(sizeof(char) * PAGE_SIZE, GFP_KERNEL);
     if (!path)
@@ -263,7 +263,7 @@ static int rfs_flt_paths_rem_name(redirfs_filter filter, const char *buf,
     struct rfs_path *rpath;
     int rv;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     path = kzalloc(sizeof(char) * PAGE_SIZE, GFP_KERNEL);
     if (!path)
@@ -453,7 +453,7 @@ int rfs_sysfs_create(void)
 {
     int rv;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     rfs_fs_kobj = kzalloc(sizeof(struct kobject), GFP_KERNEL);
     if (!rfs_fs_kobj)
@@ -535,7 +535,7 @@ int rfs_sysfs_create(void)
 {
     int rv;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     rfs_kobj = kzalloc(sizeof(struct kobject), GFP_KERNEL);
     if (!rfs_kobj)
@@ -596,7 +596,7 @@ int rfs_sysfs_create(void)
 {
     int rv;
 
-    DBG_BUG_ON(!preemptible());
+    DBG_BUG_ON(!rfs_preemptible());
 
     rfs_kobj = kzalloc(sizeof(struct kobject), GFP_KERNEL);
     if (!rfs_kobj)


### PR DESCRIPTION
This changes fix kernel panics (cifs, vfat)
Fire open notification when first operation over file occurs(nfs doesn't call open over file sometimes).
AV dont need to be notified about close file when it was open on RDONLY.