### PR TITLE
bugfixes

### DIFF
--- a/src/avflt/avflt.h
+++ b/src/avflt/avflt.h
@@ -73,6 +73,7 @@ struct avflt_event {
     int cache;
     pid_t pid;
     pid_t tgid;
+    int was_removed_from_req_list;
 };
 
 struct avflt_event *avflt_event_get(struct avflt_event *event);

--- a/src/avflt/avflt_check.c
+++ b/src/avflt/avflt_check.c
@@ -198,8 +198,9 @@ static int avflt_wait_for_reply(struct avflt_event *event)
         return (int)jiffies;
 
     if (!jiffies) {
-        printk(KERN_WARNING "avflt: wait for reply timeout\n");
-        return -ETIMEDOUT;
+        printk(KERN_WARNING "avflt: wait for reply timeout with id=%d\n", event->id);
+        event->result = AVFLT_FILE_CLEAN;
+        event->cache = 0;
     }
 
     return 0;

--- a/src/avflt/avflt_check.c
+++ b/src/avflt/avflt_check.c
@@ -198,7 +198,7 @@ static int avflt_wait_for_reply(struct avflt_event *event)
         return (int)jiffies;
 
     if (!jiffies) {
-        printk(KERN_WARNING "avflt: wait for reply timeout with id=%d\n", event->id);
+        printk(KERN_WARNING "avflt: wait for reply timeout\n");
         event->result = AVFLT_FILE_CLEAN;
         event->cache = 0;
     }

--- a/src/avflt/avflt_dev.c
+++ b/src/avflt/avflt_dev.c
@@ -106,6 +106,7 @@ static ssize_t avflt_dev_read(struct file *file, char __user *buf,
     rv = avflt_add_reply(event);
     if (rv)
         goto error;
+    avlft_pr_debug("%s", buf);
 
     avflt_install_fd(event);
     avflt_event_put(event);
@@ -126,6 +127,7 @@ static ssize_t avflt_dev_write(struct file *file, const char __user *buf,
       
     while(delimeter) {
         event = avflt_get_reply(iter, delimeter + 1 - iter);
+        avlft_pr_debug("%s", iter);
         if (IS_ERR(event))
             return PTR_ERR(event);
 

--- a/src/avflt/avflt_dev.c
+++ b/src/avflt/avflt_dev.c
@@ -121,14 +121,24 @@ static ssize_t avflt_dev_write(struct file *file, const char __user *buf,
         size_t size, loff_t *pos)
 {
     struct avflt_event *event;
+    const char* iter = buf;
+    const char* delimeter = memchr(iter, '\0', size);
+      
+    while(delimeter) {
+        event = avflt_get_reply(iter, delimeter + 1 - iter);
+        if (IS_ERR(event))
+            return PTR_ERR(event);
 
-    event = avflt_get_reply(buf, size);
-    if (IS_ERR(event))
-        return PTR_ERR(event);
-
-    avflt_event_done(event);
-    avflt_event_put(event);
-    return size;
+        avflt_event_done(event);
+        avflt_event_put(event);
+        iter = delimeter + 1;
+        if (iter - buf < size) {
+            delimeter = memchr(iter, '\0', size - (iter - buf));
+        } else {
+            break;
+        }
+    }
+    return iter - buf;
 }
 
 static unsigned int avflt_poll(struct file *file, poll_table *wait)

--- a/src/libav/Makefile
+++ b/src/libav/Makefile
@@ -6,11 +6,11 @@ CFLAGS += -g -O0
 endif
 
 VMAR := 0
-VMIN := 2
+VMIN := 3
 VREL := 0
 LIB_NAME := libav
-LIB_OBJS := av.o
-LIB_SRCS := av.c
+LIB_OBJS := av.o av_ext.o
+LIB_SRCS := av.c av_ext.c
 LIB_DIR ?= /opt/redirfs/lib
 HDR_NAME := av.h
 HDR_DIR ?= /usr/include

--- a/src/libav/av.h
+++ b/src/libav/av.h
@@ -33,15 +33,25 @@ struct av_event {
     int cache;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int av_register(struct av_connection *conn);
 int av_unregister(struct av_connection *conn);
 int av_register_trusted(struct av_connection *conn);
 int av_unregister_trusted(struct av_connection *conn);
+ssize_t av_parse_request_from_buf(struct av_event *event, const char* buf, size_t size);
 int av_request(struct av_connection *conn, struct av_event *event, int timeout);
+ssize_t av_set_reply_to_buf(char* buf, size_t size, const struct av_event *event);
 int av_reply(struct av_connection *conn, struct av_event *event);
 int av_set_result(struct av_event *event, int res);
 int av_set_cache(struct av_event *event, int cache);
 int av_get_filename(struct av_event *event, char *buf, int size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/src/libav/av_ext.c
+++ b/src/libav/av_ext.c
@@ -1,0 +1,83 @@
+/*
+ *          Copyright Frantisek Hrbata 2008 - 2010.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+#include "av.h"
+
+int av_request(struct av_connection *conn, struct av_event *event, int timeout)
+{
+    struct timeval tv;
+    struct timeval *ptv;
+    char buf[256];
+    fd_set rfds;
+    int rv = 0;
+
+    if (!conn || !event || timeout < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    FD_ZERO(&rfds);
+    FD_SET(conn->fd, &rfds);
+
+    if (timeout) {
+        tv.tv_sec = timeout / 1000;
+        tv.tv_usec = (timeout - (tv.tv_sec * 1000)) * 1000;
+        ptv = &tv;
+    } else
+        ptv = NULL;
+
+    while (!rv) {
+        rv = select(conn->fd + 1, &rfds, NULL, NULL, ptv);
+        if (rv == 0) {
+            errno = ETIMEDOUT;
+            return -1;
+        }
+        if (rv == -1)
+            return -1;
+
+        rv = read(conn->fd, buf, 256);
+        if (rv == -1)
+            return -1;
+    }
+
+    if (av_parse_request_from_buf(event, buf, sizeof(buf))<0)
+       return -1;
+
+    event->res = 0;
+    event->cache = AV_CACHE_ENABLE;
+
+    return 0;
+}
+
+int av_reply(struct av_connection *conn, struct av_event *event)
+{
+    char buf[256];
+    ssize_t len;
+
+    if (!conn || !event) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    len = av_set_reply_to_buf(buf, sizeof(buf), event);
+    if (len < 0)
+       return -1;
+
+    if (write(conn->fd, buf, len) == -1)
+        return -1;
+
+    if (close(event->fd) == -1)
+        return -1;
+
+    return 0;
+}

--- a/src/libavfltctl/avfltctl.h
+++ b/src/libavfltctl/avfltctl.h
@@ -31,6 +31,10 @@ struct avfltctl_filter {
     int cache;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct avfltctl_filter *avfltctl_get_filter(void);
 void avfltctl_put_filter(struct avfltctl_filter *filter);
 int avfltctl_add_path(const char *path, int type);
@@ -46,6 +50,10 @@ int avfltctl_invalidate_path_cache(int id);
 int avfltctl_enable_path_cache(int id);
 int avfltctl_disable_path_cache(int id);
 int avfltctl_set_timeout(int timeout);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/src/librfsctl/rfsctl.h
+++ b/src/librfsctl/rfsctl.h
@@ -24,6 +24,10 @@ struct rfsctl_filter {
     int active;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct rfsctl_filter *rfsctl_get_filter(const char *name);
 void rfsctl_put_filter(struct rfsctl_filter *filter);
 struct rfsctl_filter **rfsctl_get_filters(void);
@@ -39,6 +43,10 @@ int rfsctl_read_data(const char *fltname, const char *filename, char *buf,
         int size);
 int rfsctl_write_data(const char *fltname, const char *filename, char *buf,
         int size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/src/redirfs/rfs_dentry.c
+++ b/src/redirfs/rfs_dentry.c
@@ -238,8 +238,9 @@ struct rfs_dentry *rfs_dentry_add(struct dentry *dentry, struct rfs_info *rinfo)
         spin_unlock(&dentry->d_lock);
         return rd_new;
     }
-
+#ifndef RFS_PER_OBJECT_OPS
     DBG_BUG_ON(!rd_new->d_rhops);
+#endif
     rd_new->rinfo = rfs_info_get(rinfo);
 #ifdef RFS_PER_OBJECT_OPS
     dentry->d_op = &rd_new->op_new;

--- a/src/redirfs/rfs_file.c
+++ b/src/redirfs/rfs_file.c
@@ -658,7 +658,9 @@ static void rfs_file_set_ops_dir(struct rfs_file *rfile)
     rfile->op_new.readdir = rfs_readdir;
 #else
     rfile->op_new.iterate = rfs_iterate;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0))
     rfile->op_new.iterate_shared = rfs_iterate_shared;
+#endif
 #endif
 #else /* RFS_PER_OBJECT_OPS  */
     #define PROTOTYPE_FOP(old_op, new_op) \


### PR DESCRIPTION
Fixes:
  - compile libav with C++ code
  - avflt: returns allow access when timeout occurs
  - avflt: fix of removing events when avflt descriptor was released
  - redirfs: fix of deadlock caused by spinlock
 