### PR TITLE
fix "module in use error" when rmmod

### DIFF
--- a/src/redirfs/rfs.c
+++ b/src/redirfs/rfs.c
@@ -188,7 +188,13 @@ err_dentry_cache:
     return rv;
 }
 
+void rfs_exit(void) {
+    extern int rfs_sysfs_remove(void);
+    rfs_sysfs_remove();
+}
+
 module_init(rfs_init);
+module_exit(rfs_exit);
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Frantisek Hrbata <frantisek.hrbata@redirfs.org>");

--- a/src/redirfs/rfs_sysfs.c
+++ b/src/redirfs/rfs_sysfs.c
@@ -798,6 +798,22 @@ void rfs_flt_sysfs_exit(struct rfs_flt *rflt)
     kobject_del(&rflt->kobj);
 }
 
+int rfs_sysfs_remove(void)
+{
+    sysfs_remove_file(rfs_info_kobj, &stat_attr.attr);
+
+    if (rfs_info_kobj)
+        kobject_put(rfs_info_kobj);
+
+    if (rfs_flt_kset)
+        kobject_put(&rfs_flt_kset->kobj);
+
+    if (rfs_kobj)
+        kobject_put(rfs_kobj);
+
+    return 0;
+}
+
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,25))
 
 extern ssize_t rfs_get_stat(char *buf, ssize_t size);


### PR DESCRIPTION
test:
  #insmod redirfs/redirfs.ko
  #insmod avflt/avflt.ko
  #lsmod | grep flt
    avflt                  25041  1
    redirfs               106886  1 avflt
  #echo -n "1" > /sys/fs/redirfs/filters/avflt/unregister
  #rmmod avflt
  #rmmod redirfs

*commit note*
Dear @slavaim,
committed email address vogella is an error. It's my git configuration mistake.  Let me commit collection email(tohosys) next time.
thanks.